### PR TITLE
Only show attribute names if identifying more than one attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### ????? - ??????????
+- Only show attribute names if identifying more than one attribute #4
+
 ### 0.3.0 - 2019-06-27
 - Fix identification of objects that implement `to_a`, such as Struct.
 

--- a/README.md
+++ b/README.md
@@ -54,32 +54,37 @@ Tested MRI Ruby Versions:
 `identify` outputs the `id` of the receiving object by default, if it exists and no other attributes/methods are specified.
 
 ```ruby
-my_movie.identify           # => Movie[id:1]
-my_movie.identify(:rating)  # => Movie[rating:"7/10"]
+my_movie.identify                # => Movie[1]
+```
+
+`identify` doesn't output labels if only identifying a single attribute/method. It includes labels when two or more attributes/methods are being identified.
+
+```ruby
+my_movie.identify(:id)           # => Movie[1]
+my_movie.identify(:rating)       # => Movie["7/10"]
+my_movie.identify(:id, :rating)  # => Movie[id:1, rating:"7/10"]
 ```
 
 Private methods can be identified just the same as public methods.
 
 ```ruby
-my_movie.identify(:my_private_method)  # => Movie[my_private_method:"Shh"]
+my_movie.identify(:my_private_method)  # => Movie["Shh"]
 ```
-
 
 ### Unknown Attributes/Methods
 
 If the object doesn't respond to a specified attribute/method it is simply ignored:
 
 ```ruby
-my_movie.identify(:gobble_gobble, :rating)  # => Movie[rating:"7/10"]
+my_movie.identify(:id, :rating, :other)  # => Movie[id:1, rating:"7/10"]
 ```
 
 ### Overriding Class Names
 
 ```ruby
-my_delayed_job.identify(klass: "Delayed::Job")  # => Delayed::Job[id:1]
-my_movie.identify(klass: nil)                   # => [id:1]
+my_delayed_job.identify(klass: "Delayed::Job")  # => Delayed::Job[1]
+my_movie.identify(klass: nil)                   # => [1]
 ```
-
 
 ### Identifying Nil
 
@@ -87,7 +92,6 @@ my_movie.identify(klass: nil)                   # => [id:1]
 nil.identify(:id, :name)                 # => [no objects]
 nil.identify(:id, :name, klass: "Nope")  # => [no objects]
 ```
-
 
 ### Collections
 
@@ -101,7 +105,7 @@ Collections of objects are each identified in turn.
 The number of results that will be identified from a collection can be truncated by specifying the `limit` option.
 
 ```ruby
-[my_movie, my_contact].identify(:id, :name, limit: 1)
+[my_movie, my_user].identify(:id, :name, limit: 1)
 # => Movie[id:1, name:"Pi"], ... (1 more)
 ```
 

--- a/lib/object_identifier/identifier.rb
+++ b/lib/object_identifier/identifier.rb
@@ -90,9 +90,17 @@ module ObjectIdentifier
     def format_attributes(attributes_hash)
       return if attributes_hash.empty?
 
-      attributes_hash.map { |(key, value)|
-        "#{key}:#{value.inspect_lit}"
-      }.join(", ")
+      attributes_hash.
+        map(&format_attributes_map_block(attributes_hash)).
+        join(", ")
+    end
+
+    def format_attributes_map_block(attributes_hash)
+      if attributes_hash.one?
+        ->(key, value) { value.inspect_lit }
+      else
+        ->(key, value) { "#{key}:#{value.inspect_lit}" }
+      end
     end
 
     # @return [Hash]

--- a/test/object_identifier/identifier_test.rb
+++ b/test/object_identifier/identifier_test.rb
@@ -9,29 +9,29 @@ module ObjectIdentifier
         context "GIVEN a single object" do
           it "returns attribute values" do
             subject = OpenStruct.new(name: "Pepper", beak_size: 4)
-            subject.identify(:beak_size).must_equal "OpenStruct[beak_size:4]"
+            subject.identify(:beak_size).must_equal "OpenStruct[4]"
           end
 
           it "quotes Strings in attributes" do
             subject = OpenStruct.new(name: "Pepper")
-            subject.identify(:name).must_equal %(OpenStruct[name:"Pepper"])
+            subject.identify(:name).must_equal %(OpenStruct["Pepper"])
           end
 
           it "quotes symbols in attributes" do
             subject = OpenStruct.new(name: "Pepper", color: :grey)
-            subject.identify(:color).must_equal %(OpenStruct[color::"grey"])
+            subject.identify(:color).must_equal %(OpenStruct[:"grey"])
           end
 
           it "ignores attributes that don't exist" do
             subject = OpenStruct.new(name: "Pepper", color: :grey, beak_size: 4)
             subject.identify(:volume, :beak_size).
-              must_equal "OpenStruct[beak_size:4]"
+              must_equal "OpenStruct[4]"
           end
 
           it "returns the value of instance variables" do
             subject = OpenStruct.new
             subject.instance_variable_set(:@var1, 1)
-            subject.identify(:@var1).must_equal "OpenStruct[@var1:1]"
+            subject.identify(:@var1).must_equal "OpenStruct[1]"
           end
 
           it "returns '[no objects]', GIVEN nil" do
@@ -39,11 +39,22 @@ module ObjectIdentifier
             subject.identify.must_equal "[no objects]"
           end
 
+          context "GIVEN identifying more than a single attribute" do
+            it "returns including the attribute names" do
+              subject =
+                OpenStruct.new(name: "Pepper", beak_size: 4, color: :grey)
+              subject.instance_variable_set(:@var1, 1)
+
+              subject.identify(:name, :beak_size, :color, :@var1).must_equal(
+                %(OpenStruct[name:"Pepper", beak_size:4, color::"grey", @var1:1]))
+            end
+          end
+
           context "GIVEN object responds to :id" do
             subject { OpenStruct.new(id: 1) }
 
-            it "returns 'Class[id:1]', GIVEN no other attributes" do
-              subject.identify.must_equal "OpenStruct[id:1]"
+            it "returns 'Class[<id value>]', GIVEN no other attributes" do
+              subject.identify.must_equal "OpenStruct[1]"
             end
           end
 
@@ -59,15 +70,15 @@ module ObjectIdentifier
             subject { OpenStruct.new(id: 1) }
 
             it "overrides object class name" do
-              subject.identify(klass: "Bird").must_equal "Bird[id:1]"
+              subject.identify(klass: "Bird").must_equal "Bird[1]"
             end
 
             it "returns no class, GIVEN :klass is nil" do
-              subject.identify(klass: nil).must_equal "[id:1]"
+              subject.identify(klass: nil).must_equal "[1]"
             end
 
             it "returns no class, GIVEN :klass is empty String" do
-              subject.identify(klass: "").must_equal "[id:1]"
+              subject.identify(klass: "").must_equal "[1]"
             end
           end
 
@@ -75,7 +86,7 @@ module ObjectIdentifier
             subject { OpenStruct.new(id: 1) }
 
             it "ignores :limit" do
-              subject.identify(:id, limit: 3).must_equal "OpenStruct[id:1]"
+              subject.identify(:id, limit: 3).must_equal "OpenStruct[1]"
             end
           end
         end
@@ -83,7 +94,7 @@ module ObjectIdentifier
         context "GIVEN a collection of objects" do
           it "identifies each object in turn" do
             subject = [OpenStruct.new(id: 1), OpenStruct.new(id: 2)]
-            subject.identify.must_equal "OpenStruct[id:1], OpenStruct[id:2]"
+            subject.identify.must_equal "OpenStruct[1], OpenStruct[2]"
           end
 
           it "returns '[no objects]', GIVEN an empty Array" do
@@ -100,15 +111,15 @@ module ObjectIdentifier
             subject { [OpenStruct.new(id: 1), Object.new] }
 
             it "overrides object class name for all objects" do
-              subject.identify(klass: "Bird").must_equal "Bird[id:1], Bird[]"
+              subject.identify(klass: "Bird").must_equal "Bird[1], Bird[]"
             end
 
             it "returns no class, GIVEN :klass is nil" do
-              subject.identify(klass: nil).must_equal "[id:1], []"
+              subject.identify(klass: nil).must_equal "[1], []"
             end
 
             it "returns no class, GIVEN :klass is empty String" do
-              subject.identify(klass: "").must_equal "[id:1], []"
+              subject.identify(klass: "").must_equal "[1], []"
             end
           end
 
@@ -116,9 +127,9 @@ module ObjectIdentifier
             it "returns truncated list, GIVEN :limit" do
               subject = "abcdefg".chars
               subject.identify(:upcase, limit: 3).must_equal(
-                "String[upcase:\"A\"], "\
-                "String[upcase:\"B\"], "\
-                "String[upcase:\"C\"], ... (4 more)")
+                "String[\"A\"], "\
+                "String[\"B\"], "\
+                "String[\"C\"], ... (4 more)")
             end
           end
         end
@@ -128,7 +139,7 @@ module ObjectIdentifier
 
           it "returns the expected String" do
             value(subject.identify).must_equal(
-              "ObjectIdentifier::IdentifierTest::TestStruct[id:1]")
+              "ObjectIdentifier::IdentifierTest::TestStruct[1]")
           end
 
           TestStruct = Struct.new(:id)


### PR DESCRIPTION
If you are only identifying a single attribute, don't show the
attribute name. Given that the attribute should be an identifier
(b/c you are _identifying_ with it), this reduces noise in the
output without loss of clarity.

```ruby
subject = OpenStruct.new(id: 12345, name: "Thing 1")

subject.identify # => "OpenStruct[12345]"
subject.identify(:id) # => "OpenStruct[12345]"
subject.identify(:id, :name) # => "OpenStruct[id:12345, name:\"Thing 1\"]"
subject.identify(:name) # => # => "OpenStruct[\"Thing 1\"]"
```